### PR TITLE
fix: 졸업요건 분석 기능 개선 및 버그 수정

### DIFF
--- a/graduateCheck/graduateCheck/urls.py
+++ b/graduateCheck/graduateCheck/urls.py
@@ -19,10 +19,12 @@ from django.contrib import admin
 from django.urls import path
 from django.conf import settings
 from django.conf.urls.static import static
-from myapp.views import upload_file, cleanup_files
+from myapp.views import upload_file, cleanup_files, analyze
 
 urlpatterns = [
     path('admin/', admin.site.urls),
-    path('', upload_file, name='upload_file'),
-    path('cleanup/', cleanup_files, name='cleanup_files'),
+    path('', upload_file, name='index'),
+    path('upload/', upload_file, name='upload'),
+    path('analyze/', analyze, name='analyze'),
+    path('cleanup/', cleanup_files, name='cleanup'),
 ] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)

--- a/graduateCheck/myapp/templates/result.html
+++ b/graduateCheck/myapp/templates/result.html
@@ -1,74 +1,89 @@
 {% extends 'base.html' %}
 
 {% block content %}
-<div class="row justify-content-center">
-    <div class="col-md-8">
-        <div class="card">
-            <div class="card-header">
-                <h3 class="text-center">졸업요건 분석 결과</h3>
-            </div>
-            <div class="card-body">
-                {% if result.error %}
-                <div class="alert alert-danger">
-                    <h4 class="alert-heading">오류 발생</h4>
-                    <p>{{ result.error }}</p>
-                    <hr>
-                    <p class="mb-0">엑셀 파일의 형식을 확인해주세요. 필요한 컬럼: 학점, 과목명</p>
+<div class="container mt-5">
+    <div class="row justify-content-center">
+        <div class="col-md-8">
+            <div class="card">
+                <div class="card-header">
+                    <h3 class="text-center">졸업요건 분석 결과</h3>
                 </div>
-                {% else %}
-                <div class="alert {% if result.status == '졸업가능' %}alert-success{% else %}alert-danger{% endif %}">
-                    <h4 class="alert-heading">현재 상태: {{ result.status }}</h4>
-                </div>
+                <div class="card-body">
+                    {% if result.error %}
+                    <div class="alert alert-danger">
+                        <h4 class="alert-heading">오류 발생</h4>
+                        <p>{{ result.error }}</p>
+                        <hr>
+                        <p class="mb-0">엑셀 파일의 형식을 확인해주세요. 필요한 컬럼: 학점, 과목명</p>
+                    </div>
+                    {% else %}
+                    <div class="alert {% if result.status == '졸업가능' %}alert-success{% else %}alert-danger{% endif %}">
+                        <h4 class="alert-heading">{{ result.status }}</h4>
+                        <p>총 이수학점: {{ result.total_credits }}학점</p>
+                    </div>
 
-                <h5>총 이수학점: {{ result.total_credits }}</h5>
-
-                {% if result.required_courses %}
-                <h5 class="mt-4">필수과목 이수 현황:</h5>
-                <div class="table-responsive">
-                    <table class="table table-striped">
-                        <thead>
-                            <tr>
-                                <th>과목명</th>
-                                <th>이수구분</th>
-                            </tr>
-                        </thead>
-                        <tbody>
-                            {% for course in result.required_courses %}
-                            <tr>
-                                <td>{{ course.course_name }}</td>
-                                <td>{{ course.category }}</td>
-                            </tr>
+                    {% if result.details %}
+                    <div class="mb-4">
+                        <h5>세부 요건 현황</h5>
+                        <ul class="list-group">
+                            {% for key, value in result.details.items %}
+                            <li class="list-group-item d-flex justify-content-between align-items-center">
+                                {{ key }}
+                                <span class="badge {% if value == '충족' %}bg-success{% else %}bg-danger{% endif %} rounded-pill">
+                                    {{ value }}
+                                </span>
+                            </li>
                             {% endfor %}
-                        </tbody>
-                    </table>
-                </div>
-                {% endif %}
+                        </ul>
+                    </div>
+                    {% endif %}
 
-                {% if result.missing_courses %}
-                <h5 class="mt-4">미이수 필수과목:</h5>
-                <div class="table-responsive">
-                    <table class="table table-striped">
-                        <thead>
-                            <tr>
-                                <th>과목명</th>
-                                <th>이수구분</th>
-                            </tr>
-                        </thead>
-                        <tbody>
-                            {% for course in result.missing_courses %}
-                            <tr class="table-danger">
-                                <td>{{ course.course_name }}</td>
-                                <td>{{ course.category }}</td>
-                            </tr>
+                    <div class="mb-4">
+                        <h5 class="text-success">이수한 필수 과목</h5>
+                        {% if result.required_courses %}
+                            {% for category, courses in result.required_courses.items %}
+                                <div class="mb-3">
+                                    <h6 class="text-muted">{{ category }}</h6>
+                                    <ul class="list-group">
+                                        {% for course in courses %}
+                                            <li class="list-group-item d-flex justify-content-between align-items-center">
+                                                {{ course.course_name }}
+                                                <span class="badge bg-primary rounded-pill">{{ course.credits }}학점</span>
+                                            </li>
+                                        {% endfor %}
+                                    </ul>
+                                </div>
                             {% endfor %}
-                        </tbody>
-                    </table>
-                </div>
-                {% endif %}
-                {% endif %}
+                        {% else %}
+                            <p class="text-muted">이수한 필수 과목이 없습니다.</p>
+                        {% endif %}
+                    </div>
 
-                <div class="d-grid gap-2 mt-4">
-                    <a href="/" class="btn btn-primary">새로운 파일 업로드</a>
+                    <div class="mb-4">
+                        <h5 class="text-danger">미이수 필수 과목</h5>
+                        {% if result.missing_courses %}
+                            {% for category, courses in result.missing_courses.items %}
+                                <div class="mb-3">
+                                    <h6 class="text-muted">{{ category }}</h6>
+                                    <ul class="list-group">
+                                        {% for course in courses %}
+                                            <li class="list-group-item d-flex justify-content-between align-items-center">
+                                                {{ course.course_name }}
+                                                <span class="badge bg-primary rounded-pill">{{ course.credits }}학점</span>
+                                            </li>
+                                        {% endfor %}
+                                    </ul>
+                                </div>
+                            {% endfor %}
+                        {% else %}
+                            <p class="text-muted">미이수 필수 과목이 없습니다.</p>
+                        {% endif %}
+                    </div>
+                    {% endif %}
+
+                    <div class="text-center mt-4">
+                        <a href="{% url 'index' %}" class="btn btn-primary">새로운 분석하기</a>
+                    </div>
                 </div>
             </div>
         </div>

--- a/graduateCheck/myapp/templates/upload.html
+++ b/graduateCheck/myapp/templates/upload.html
@@ -1,29 +1,61 @@
 {% extends 'base.html' %}
 
 {% block content %}
-<div class="row justify-content-center">
-    <div class="col-md-6">
-        <div class="card">
-            <div class="card-header">
-                <h3 class="text-center">졸업요건 체크</h3>
-            </div>
-            <div class="card-body">
-                {% if error %}
-                <div class="alert alert-danger">
-                    {{ error }}
+<div class="container mt-5">
+    <div class="row justify-content-center">
+        <div class="col-md-8">
+            <div class="card">
+                <div class="card-header">
+                    <h3 class="text-center">졸업요건 체크</h3>
                 </div>
-                {% endif %}
-                
-                <form method="post" enctype="multipart/form-data">
-                    {% csrf_token %}
-                    <div class="mb-3">
-                        <label for="excel_file" class="form-label">수강과목 엑셀 파일 업로드</label>
-                        <input type="file" class="form-control" id="excel_file" name="excel_file" accept=".xlsx,.xls" required>
+                <div class="card-body">
+                    {% if error %}
+                    <div class="alert alert-danger">
+                        {{ error }}
                     </div>
-                    <div class="d-grid">
-                        <button type="submit" class="btn btn-primary">분석 시작</button>
-                    </div>
-                </form>
+                    {% endif %}
+                    
+                    <form method="post" enctype="multipart/form-data">
+                        {% csrf_token %}
+                        
+                        <div class="mb-4">
+                            <label class="form-label">학생 유형 선택</label>
+                            <div class="form-check">
+                                <input class="form-check-input" type="radio" name="student_type" id="type_normal" value="normal" checked>
+                                <label class="form-check-label" for="type_normal">
+                                    일반학생
+                                </label>
+                            </div>
+                            <div class="form-check">
+                                <input class="form-check-input" type="radio" name="student_type" id="type_transfer" value="transfer">
+                                <label class="form-check-label" for="type_transfer">
+                                    편입생
+                                </label>
+                            </div>
+                            <div class="form-check">
+                                <input class="form-check-input" type="radio" name="student_type" id="type_double" value="double">
+                                <label class="form-check-label" for="type_double">
+                                    다전공자
+                                </label>
+                            </div>
+                            <div class="form-check">
+                                <input class="form-check-input" type="radio" name="student_type" id="type_minor" value="minor">
+                                <label class="form-check-label" for="type_minor">
+                                    부전공자
+                                </label>
+                            </div>
+                        </div>
+
+                        <div class="mb-3">
+                            <label for="excel_file" class="form-label">엑셀 파일 업로드</label>
+                            <input type="file" class="form-control" id="excel_file" name="excel_file" accept=".xlsx,.xls" required>
+                            <div class="form-text">지원 형식: .xlsx, .xls</div>
+                        </div>
+                        <div class="text-center">
+                            <button type="submit" class="btn btn-primary">분석하기</button>
+                        </div>
+                    </form>
+                </div>
             </div>
         </div>
     </div>

--- a/graduateCheck/myapp/views.py
+++ b/graduateCheck/myapp/views.py
@@ -1,5 +1,5 @@
 from django.shortcuts import render
-from django.http import HttpResponse
+from django.http import HttpResponse, JsonResponse
 import pandas as pd
 import os
 from django.conf import settings
@@ -7,6 +7,8 @@ from django.views.decorators.http import require_http_methods
 import uuid
 import warnings
 import numpy as np
+from django.views.decorators.csrf import csrf_exempt
+import json
 
 # openpyxl 경고 메시지 숨기기
 warnings.filterwarnings('ignore', category=UserWarning, module='openpyxl')
@@ -41,62 +43,54 @@ def parse_grade_table(df):
     return data
 
 def clean_dataframe(df):
-    """엑셀 데이터 정제 함수"""
-    # 1. 헤더 탐색
-    headers = explore_headers(df)
-    
-    # 2. 컬럼명 정제
-    df.columns = df.columns.str.strip().str.lower()
-    
-    # 3. 빈 컬럼 제거
-    df = df.dropna(axis=1, how='all')
-    
-    # 4. 모든 행이 NaN인 행 제거
-    df = df.dropna(how='all')
-    
-    # 5. 컬럼명 매핑
-    column_mapping = {
-        # 학점 관련 컬럼
-        '학점': 'credits',
-        '이수학점': 'credits',
-        '학점수': 'credits',
-        'credits': 'credits',
-        'credit': 'credits',
-        # 과목명 관련 컬럼
-        '과목명': 'course_name',
-        '과목': 'course_name',
-        '교과목명': 'course_name',
-        'course': 'course_name',
-        'course name': 'course_name',
-        # 과목유형 관련 컬럼
-        '과목유형': 'course_type',
-        '유형': 'course_type',
-        'type': 'course_type',
-        'course type': 'course_type',
-        # 이수구분 관련 컬럼
-        '이수구분': 'course_type',
-        '구분': 'course_type',
-        'classification': 'course_type'
-    }
-    
-    # 6. 컬럼명 변경
-    df = df.rename(columns=column_mapping)
-    
-    # 7. 필요한 컬럼이 있는지 확인
-    required_columns = ['credits', 'course_name']
-    missing_columns = [col for col in required_columns if col not in df.columns]
-    
-    if missing_columns:
-        raise ValueError(f"필수 컬럼이 없습니다: {', '.join(missing_columns)}")
-    
-    # 8. 데이터 타입 변환
-    df['credits'] = pd.to_numeric(df['credits'], errors='coerce')
-    
-    # 9. NaN 값 처리
-    df = df.dropna(subset=['credits', 'course_name'])
-    
-    print("정제 후 컬럼:", df.columns.tolist())
-    return df
+    """데이터프레임 정제"""
+    try:
+        # 1. 컬럼명 정규화
+        df.columns = [str(col).strip().lower() for col in df.columns]
+        
+        # 2. 필수 컬럼 확인 및 생성
+        required_columns = ['과목명', '이수구분', '학점']
+        for col in required_columns:
+            if col not in df.columns:
+                if col == '과목명':
+                    df.loc[:, '과목명'] = df['교과목명']
+                elif col == '이수구분':
+                    df.loc[:, '이수구분'] = df['과목구분']
+                elif col == '학점':
+                    df.loc[:, '학점'] = df['학점수']
+        
+        # 3. 데이터 정제
+        df = df.dropna(subset=['과목명', '이수구분', '학점']).copy()
+        
+        # 문자열 데이터만 strip() 적용
+        if df['과목명'].dtype == 'object':
+            df.loc[:, '과목명'] = df['과목명'].str.strip()
+        if df['이수구분'].dtype == 'object':
+            df.loc[:, '이수구분'] = df['이수구분'].str.strip()
+            
+        # 학점은 숫자로 변환
+        df.loc[:, '학점'] = pd.to_numeric(df['학점'], errors='coerce')
+        
+        # 4. 과목명에서 띄어쓰기 제거 (문자열 데이터만)
+        if df['과목명'].dtype == 'object':
+            df.loc[:, '과목명'] = df['과목명'].str.replace(' ', '')
+        
+        # 5. '취득학점포기' 데이터 처리
+        if '삭제구분' in df.columns:
+            # '취득학점포기'가 아닌 데이터만 선택
+            df = df[df['삭제구분'] != '취득학점포기'].copy()
+        
+        # 6. 컬럼명 영문으로 변경
+        df = df.rename(columns={
+            '과목명': 'course_name',
+            '이수구분': 'course_type',
+            '학점': 'credits'
+        })
+        
+        return df
+    except Exception as e:
+        print(f"데이터 정제 중 오류 발생: {str(e)}")
+        raise
 
 def filter_keyword_rows(df, keyword_column, keywords):
     """특정 키워드가 포함된 행 필터링"""
@@ -111,6 +105,7 @@ def filter_keyword_rows(df, keyword_column, keywords):
 def upload_file(request):
     if request.method == 'POST' and request.FILES['excel_file']:
         excel_file = request.FILES['excel_file']
+        student_type = request.POST.get('student_type', 'normal')  # 기본값은 'normal'
         
         # 고유한 파일명 생성
         unique_filename = f"{uuid.uuid4()}_{excel_file.name}"
@@ -153,7 +148,7 @@ def upload_file(request):
                 print(f"키워드 필터링 중 오류 발생: {str(e)}")
                 # 필터링 실패해도 계속 진행
             
-            result = analyze_graduation_requirements(df)
+            result = analyze_graduation_requirements(df, student_type)
             return render(request, 'result.html', {'result': result})
         except Exception as e:
             # 에러 발생 시 파일 삭제
@@ -171,49 +166,326 @@ def cleanup_files(request):
         os.remove(file_path)
     return HttpResponse(status=200)
 
-def analyze_graduation_requirements(df):
-    # 필수 과목 목록 (실제 이수구분에 맞게 수정)
-    required_courses = {
-        '전선': ['인식론', '자료구조', '알고리즘', '운영체제', '데이터베이스'],
-        '지교': ['대학영어', '대학수학', '글쓰기'],
-        '핵교': ['철학의 이해', '윤리학', '논리학']
+def get_graduation_requirements(student_type):
+    requirements = {
+        'normal': {
+            'common_required': {
+                '심교': ['철학산책', '철학의이해'],
+                '지교': 5  # 문과대학 지정교양 과목 5개
+            },
+            '전선': [
+                '철학의문제들',
+                '동양사상과현실문제',
+                '논리학',
+                '서양철학고전읽기',
+                '동양철학고전읽기',
+                '서양고중세철학',
+                '학술답사Ⅰ',
+                '학술답사Ⅱ',
+                '학술답사Ⅲ',
+                '중국철학의이해',
+                '윤리학',
+                '서양근세철학',
+                '인식론',
+                '형이상학',
+                '한국철학의이해',
+                '서양현대철학'
+            ],
+            '전선_min': 4,  # 전공선택 과목 중 4개 이상
+            'internship_required': True
+        },
+        'transfer': {
+            '전선': [
+                '서양고중세철학',
+                '학술답사Ⅰ',
+                '학술답사Ⅱ',
+                '학술답사Ⅲ',
+                '중국철학의이해',
+                '윤리학',
+                '서양근세철학',
+                '인식론',
+                '형이상학',
+                '한국철학의이해',
+                '중국유학'
+            ],
+            '전선_min': 3  # 5개 중 3개 이상
+        },
+        'double': {
+            'common_required': {
+                '심교': ['철학산책', '철학의이해']
+            },
+            '전선': [
+                '서양고중세철학',
+                '중국철학의이해',
+                '윤리학',
+                '인식론',
+                '서양근세철학',
+                '한국철학의이해',
+                '형이상학'
+            ],
+            '전선_min': 4  # 7개 중 4개 이상
+        },
+        'minor': {
+            '전선': [
+                '철학의문제들',
+                '논리학',
+                '중국철학의이해',
+                '윤리학',
+                '서양근세철학',
+                '인식론',
+                '형이상학',
+                '한국철학의이해',
+                '서양현대철학'
+            ],
+            '전선_min': 3  # 6개 중 3개 이상
+        }
     }
-    
-    # 결과 초기화
+    return requirements.get(student_type, {})
+
+def analyze_graduation_requirements(df, student_type):
+    requirements = get_graduation_requirements(student_type)
     result = {
         'total_credits': 0,
-        'required_courses': [],
-        'missing_courses': [],
-        'status': '미졸업'
+        'required_courses': {},
+        'missing_courses': {},
+        'status': '미졸업',
+        'details': {}
     }
     
     try:
         # 총 이수학점 계산
         result['total_credits'] = df['credits'].sum()
         
-        # 필수과목 이수 현황 체크
-        for category, courses in required_courses.items():
-            for course in courses:
-                # 키워드가 포함된 행 탐색
-                course_data = df[df['course_name'].str.contains(course, case=False, na=False)]
+        # 공통 필수 과목 체크 (일반학생, 다전공자)
+        if 'common_required' in requirements:
+            for category, courses in requirements['common_required'].items():
+                if isinstance(courses, list):
+                    for course in courses:
+                        # 심교와 핵교를 같은 이수구분으로 처리
+                        if category == '심교':
+                            course_data = df[
+                                (df['course_name'].str.contains(course, case=False, na=False)) & 
+                                ((df['course_type'] == '심교') | (df['course_type'] == '핵교'))
+                            ]
+                        else:
+                            course_data = df[
+                                (df['course_name'].str.contains(course, case=False, na=False)) & 
+                                (df['course_type'] == category)
+                            ]
+                        
+                        if not course_data.empty:
+                            if category not in result['required_courses']:
+                                result['required_courses'][category] = []
+                            result['required_courses'][category].append({
+                                'course_name': course,
+                                'category': category,
+                                'credits': course_data['credits'].iloc[0]
+                            })
+                        else:
+                            if category not in result['missing_courses']:
+                                result['missing_courses'][category] = []
+                            result['missing_courses'][category].append({
+                                'course_name': course,
+                                'category': category,
+                                'credits': 3  # 기본 학점
+                            })
+                elif isinstance(courses, int):  # 지정교양 과목 수
+                    liberal_arts_courses = df[df['course_type'] == '지교']
+                    if len(liberal_arts_courses) >= courses:
+                        if '지교' not in result['required_courses']:
+                            result['required_courses']['지교'] = []
+                        # 실제 이수한 지정교양 과목들을 추가
+                        for _, course in liberal_arts_courses.iterrows():
+                            result['required_courses']['지교'].append({
+                                'course_name': course['course_name'],
+                                'category': '지교',
+                                'credits': course['credits']
+                            })
+                    else:
+                        if '지교' not in result['missing_courses']:
+                            result['missing_courses']['지교'] = []
+                        # 이수한 지정교양 과목들을 추가
+                        for _, course in liberal_arts_courses.iterrows():
+                            result['missing_courses']['지교'].append({
+                                'course_name': course['course_name'],
+                                'category': '지교',
+                                'credits': course['credits']
+                            })
+                        # 부족한 과목 수만큼 '미이수' 표시
+                        for _ in range(courses - len(liberal_arts_courses)):
+                            result['missing_courses']['지교'].append({
+                                'course_name': '지정교양 미이수',
+                                'category': '지교',
+                                'credits': 3
+                            })
+        
+        # 전공 과목 체크 (전선으로 통합)
+        if '전선' in requirements:
+            select_count = 0
+            for course in requirements['전선']:
+                course_data = df[
+                    (df['course_name'].str.contains(course, case=False, na=False)) & 
+                    (df['course_type'] == '전선')
+                ]
                 if not course_data.empty:
-                    result['required_courses'].append({
+                    select_count += 1
+                    if '전선' not in result['required_courses']:
+                        result['required_courses']['전선'] = []
+                    result['required_courses']['전선'].append({
                         'course_name': course,
-                        'category': category
+                        'category': '전선',
+                        'credits': course_data['credits'].iloc[0]
                     })
                 else:
-                    result['missing_courses'].append({
+                    if '전선' not in result['missing_courses']:
+                        result['missing_courses']['전선'] = []
+                    result['missing_courses']['전선'].append({
                         'course_name': course,
-                        'category': category
+                        'category': '전선',
+                        'credits': 3  # 기본 학점
                     })
+            
+            if select_count >= requirements['전선_min']:
+                result['details']['전선'] = '충족'
+            else:
+                result['details']['전선'] = '미충족'
+        
+        # 인턴십 체크 (일반학생)
+        if requirements.get('internship_required', False):
+            internship_courses = df[df['course_name'].str.contains('인턴십', case=False, na=False)]
+            if not internship_courses.empty:
+                result['details']['인턴십'] = '충족'
+            else:
+                result['details']['인턴십'] = '미충족'
         
         # 졸업 가능 여부 판단
         if (result['total_credits'] >= 130 and  # 총 이수학점 130학점 이상
-            len(result['missing_courses']) == 0):  # 모든 필수과목 이수
+            len(result['missing_courses']) == 0 and  # 모든 필수과목 이수
+            all(status == '충족' for status in result['details'].values())):  # 모든 세부요건 충족
             result['status'] = '졸업가능'
+        
+        # 각 이수구분별 과목들을 가나다 순으로 정렬
+        for category in result['required_courses']:
+            result['required_courses'][category] = sorted(
+                result['required_courses'][category],
+                key=lambda x: x['course_name']
+            )
+        
+        for category in result['missing_courses']:
+            result['missing_courses'][category] = sorted(
+                result['missing_courses'][category],
+                key=lambda x: x['course_name']
+            )
     
     except Exception as e:
         result['error'] = str(e)
         result['status'] = '오류'
     
     return result
+
+@csrf_exempt
+def analyze(request):
+    if request.method == 'POST':
+        try:
+            excel_file = request.FILES['excel_file']
+            student_type = request.POST.get('student_type', 'normal')
+            
+            # 파일 저장
+            file_path = os.path.join(settings.MEDIA_ROOT, excel_file.name)
+            with open(file_path, 'wb+') as destination:
+                for chunk in excel_file.chunks():
+                    destination.write(chunk)
+            
+            # 엑셀 파일 읽기
+            df = pd.read_excel(file_path)
+            
+            # 졸업요건 분석
+            result = analyze_graduation_requirements(df, student_type)
+            
+            # 파일 삭제
+            os.remove(file_path)
+            
+            return render(request, 'result.html', {'result': result})
+            
+        except Exception as e:
+            return JsonResponse({'error': str(e)}, status=400)
+    
+    return JsonResponse({'error': '잘못된 요청입니다.'}, status=400)
+
+def analyze_completed_courses(df):
+    """이수한 과목 분석"""
+    completed_courses = {}
+    
+    for _, row in df.iterrows():
+        course_name = row['course_name']
+        if course_name not in completed_courses:
+            completed_courses[course_name] = {
+                'course_name': course_name,
+                'category': row['course_type'],
+                'credits': row['credits']
+            }
+    
+    return completed_courses
+
+def process_excel(df, major, student_id):
+    """엑셀 데이터 처리 및 졸업 요건 검사"""
+    try:
+        # 1. 데이터 정제
+        df = clean_dataframe(df)
+        
+        # 2. 전공별 졸업 요건 가져오기
+        requirements = get_graduation_requirements(major)
+        
+        # 3. 이수 과목 분석
+        completed_courses = analyze_completed_courses(df)
+        
+        # 4. 필수 과목 검사
+        required_courses = []
+        missing_courses = []
+        
+        for course in requirements['required_courses']:
+            if course['course_name'] in completed_courses:
+                required_courses.append({
+                    'course_name': course['course_name'],
+                    'category': course['category'],
+                    'credits': completed_courses[course['course_name']]['credits']
+                })
+            else:
+                missing_courses.append({
+                    'course_name': course['course_name'],
+                    'category': course['category'],
+                    'credits': course['credits']
+                })
+        
+        # 5. 이수구분별 과목 그룹화 및 정렬
+        def group_and_sort_courses(courses):
+            # 이수구분별로 그룹화
+            grouped = {}
+            for course in courses:
+                category = course['category']
+                if category not in grouped:
+                    grouped[category] = []
+                grouped[category].append(course)
+            
+            # 각 그룹 내에서 과목명 오름차순 정렬
+            for category in grouped:
+                grouped[category] = sorted(grouped[category], key=lambda x: x['course_name'])
+            
+            return grouped
+        
+        required_courses_grouped = group_and_sort_courses(required_courses)
+        missing_courses_grouped = group_and_sort_courses(missing_courses)
+        
+        # 6. 결과 반환
+        return {
+            'student_id': student_id,
+            'major': major,
+            'total_credits': sum(course['credits'] for course in completed_courses.values()),
+            'required_credits': requirements['required_credits'],
+            'required_courses': required_courses_grouped,
+            'missing_courses': missing_courses_grouped,
+            'elective_courses': sorted(completed_courses.values(), key=lambda x: x['course_name'])
+        }
+    except Exception as e:
+        print(f"데이터 처리 중 오류 발생: {str(e)}")
+        raise


### PR DESCRIPTION
## 개요
이 PR은 졸업요건 분석 기능을 개선하고 여러 버그를 수정하여 사용자 경험을 향상시키는 변경사항을 포함합니다. 특히 과목 표시 방식 개선, 정렬 기능 추가, 데이터 처리 로직 개선에 중점을 두었습니다.

## 주요 변경사항

### 1. 지정교양 과목 표시 방식 개선
- 기존: "지정교양 5개 이상"과 같이 개수만 표시
- 변경: 실제 이수한 지정교양 과목명을 개별적으로 나열하여 표시
- 미이수한 경우: 이수한 과목은 표시하고, 부족한 과목 수만큼 "지정교양 미이수"로 표시

### 2. 과목 목록 정렬 기능 추가
- 각 이수구분별 과목 목록을 가나다 순으로 정렬하여 가독성 향상
- 이수한 필수 과목과 미이수 필수 과목 모두에 적용

### 3. 이수구분별 과목 그룹화 기능 구현
- 과목들을 이수구분(심교, 지교, 전선 등)별로 그룹화하여 표시
- 각 그룹은 작은 제목으로 구분하고, 그 아래에 해당 과목들이 리스트로 표시

### 4. 데이터 처리 로직 개선
- '취득학점포기' 데이터 처리 로직 추가 (총 학점 계산에서 제외)
- SettingWithCopyWarning 경고 해결을 위한 DataFrame 처리 방식 개선
- analyze_completed_courses 함수 추가로 코드 구조 개선

### 5. UI/UX 개선
- 이수한 과목은 초록색, 미이수 과목은 빨간색으로 구분하여 시각적 명확성 향상
- 학점 정보를 배지 형태로 표시하여 가독성 개선

## 기술적 변경사항
- DataFrame 처리 시 .loc 접근자 사용으로 SettingWithCopyWarning 해결
- 과목 데이터 구조를 리스트에서 딕셔너리로 변경하여 이수구분별 그룹화 구현
- 문자열 데이터 타입 체크 추가로 숫자 데이터 처리 오류 해결

## 테스트 방법
1. 엑셀 파일 업로드
   - 필수 컬럼: 과목명, 이수구분, 학점
   - '취득학점포기' 데이터가 포함된 파일도 테스트
2. 학생 유형 선택 (일반학생/편입생/다전공자/부전공자)
3. 분석 결과 확인
   - 이수한 필수 과목과 미이수 필수 과목이 이수구분별로 그룹화되어 표시됨
   - 각 그룹 내 과목들이 가나다 순으로 정렬됨
   - 지정교양 과목이 개수 대신 실제 과목명으로 표시됨
   - '취득학점포기' 데이터가 총 학점 계산에서 제외됨

## 스크린샷
## 개요
이 PR은 졸업요건 분석 기능을 개선하고 여러 버그를 수정하여 사용자 경험을 향상시키는 변경사항을 포함합니다. 특히 과목 표시 방식 개선, 정렬 기능 추가, 데이터 처리 로직 개선에 중점을 두었습니다.

## 주요 변경사항

### 1. 지정교양 과목 표시 방식 개선
- 기존: "지정교양 5개 이상"과 같이 개수만 표시
- 변경: 실제 이수한 지정교양 과목명을 개별적으로 나열하여 표시
- 미이수한 경우: 이수한 과목은 표시하고, 부족한 과목 수만큼 "지정교양 미이수"로 표시

### 2. 과목 목록 정렬 기능 추가
- 각 이수구분별 과목 목록을 가나다 순으로 정렬하여 가독성 향상
- 이수한 필수 과목과 미이수 필수 과목 모두에 적용

### 3. 이수구분별 과목 그룹화 기능 구현
- 과목들을 이수구분(심교, 지교, 전선 등)별로 그룹화하여 표시
- 각 그룹은 작은 제목으로 구분하고, 그 아래에 해당 과목들이 리스트로 표시

### 4. 데이터 처리 로직 개선
- '취득학점포기' 데이터 처리 로직 추가 (총 학점 계산에서 제외)
- SettingWithCopyWarning 경고 해결을 위한 DataFrame 처리 방식 개선
- analyze_completed_courses 함수 추가로 코드 구조 개선

### 5. UI/UX 개선
- 이수한 과목은 초록색, 미이수 과목은 빨간색으로 구분하여 시각적 명확성 향상
- 학점 정보를 배지 형태로 표시하여 가독성 개선

## 기술적 변경사항
- DataFrame 처리 시 .loc 접근자 사용으로 SettingWithCopyWarning 해결
- 과목 데이터 구조를 리스트에서 딕셔너리로 변경하여 이수구분별 그룹화 구현
- 문자열 데이터 타입 체크 추가로 숫자 데이터 처리 오류 해결

## 테스트 방법
1. 엑셀 파일 업로드
   - 필수 컬럼: 과목명, 이수구분, 학점
   - '취득학점포기' 데이터가 포함된 파일도 테스트
2. 학생 유형 선택 (일반학생/편입생/다전공자/부전공자)
3. 분석 결과 확인
   - 이수한 필수 과목과 미이수 필수 과목이 이수구분별로 그룹화되어 표시됨
   - 각 그룹 내 과목들이 가나다 순으로 정렬됨
   - 지정교양 과목이 개수 대신 실제 과목명으로 표시됨
   - '취득학점포기' 데이터가 총 학점 계산에서 제외됨

## 스크린샷

https://github.com/user-attachments/assets/a286df48-e850-4831-85f4-a864474e79fe



## 관련 이슈
- #123 졸업요건 분석 기능 개선
- #124 과목 목록 정렬 및 그룹화 요청
- #125 '취득학점포기' 데이터 처리 요청

## 추가 고려사항
- 향후 과목명 일치 여부를 더 유연하게 처리하는 방법 검토 필요
- 다양한 엑셀 파일 형식에 대한 지원 확장 고려

## 추가 고려사항
- 향후 과목명 일치 여부를 더 유연하게 처리하는 방법 검토 필요
- 다양한 엑셀 파일 형식에 대한 지원 확장 고려